### PR TITLE
Knip: support pnpm

### DIFF
--- a/.buildkite/scripts/steps/checks/unused_deps.sh
+++ b/.buildkite/scripts/steps/checks/unused_deps.sh
@@ -4,14 +4,5 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-# Temporarily skipped for the pnpm migration: pnpm generates a gitignored
-# package.json per package, which knip treats as a package boundary and skips,
-# producing ~260 false-positive "unused" deps. Tracked in
-# https://github.com/elastic/kibana/issues/276638
-echo --- Check for unused dependencies "(skipped: https://github.com/elastic/kibana/issues/276638)"
-echo "Skipping knip unused-dependency check while the pnpm migration is in progress."
-echo "See https://github.com/elastic/kibana/issues/276638"
-exit 0
-
 # shellcheck disable=SC2317
-node scripts/knip --workspace . --include dependencies,devDependencies
+node scripts/knip --include dependencies,devDependencies

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -12,12 +12,6 @@
 //   node scripts/knip --workspace src/platform/packages/shared/kbn-safer-lodash-set --include unlisted
 {
   "$schema": "https://unpkg.com/knip@6/schema-jsonc.json",
-  // Disable the Playwright and Cypress plugins for every workspace (top-level plugin config
-  // is applied to all workspaces as a default). Knip's config loader tries to import each
-  // `playwright.config.ts` / `cypress.config.ts`, which transitively pulls in `*.text`
-  // mustache templates from @kbn/evals (Node can't load the `.text` extension without our
-  // runtime require hook) and hits a colorette bundling issue in the cypress configs. We
-  // don't need these config files for dependency analysis, so we skip loading them.
   "playwright": false,
   "cypress": false,
   // @kbn/* and @elastic/* are internal linked packages managed outside of knip.
@@ -37,15 +31,14 @@
     "geckodriver",
     // these are used as Cypress reporters via reporter_config.json; knip can't trace the
     // cypress-multi-reporters -> configFile -> reporterEnabled chain.
-    "buildkite-test-collector",
     "cypress-multi-reporters",
+    "buildkite-test-collector",
+    // This provides the moon binary used by @kbn/moon; knip can't trace this.
+    "@moonrepo/cli",
     "marge",
     "mocha-junit-reporter",
     "mocha-multi-reporters",
     "mochawesome",
-    // used by APM's Cypress e2e support files (ftr_e2e/); with the cypress plugin disabled
-    // (see above) knip no longer traces it through the cypress config/support chain.
-    "@frsource/cypress-plugin-visual-regression-diff",
     // oxlint is invoked as a binary via procRunner in @kbn/lint-cli;
     // knip can't trace dynamic cmd invocations.
     "oxlint"
@@ -56,6 +49,11 @@
         "**/node_modules/**",
         "**/target/**",
         "**/build/**"
+      ],
+      "entry": [
+        "scripts/**/*.{js,ts}",
+        "src/**/*.{js,ts,tsx}",
+        "x-pack/**/*.{js,ts,tsx}"
       ],
       "storybook": {
         "config": [
@@ -103,7 +101,24 @@
     "src/platform/packages/shared/kbn-test": {
       // Jest setup/polyfill/serializer files referenced from jest-preset.js via `<rootDir>/...`.
       // knip can't resolve `<rootDir>` inside a shared preset.
-      "entry": ["src/jest/setup/*.{js,ts}"]
+      "entry": ["**/*.{js,ts}"]
+    },
+    "x-pack/platform/test": {
+      "entry": ["**/*.{js,ts,tsx}"]
+    },
+    "src/platform/packages/private/kbn-scout-reporting": {
+      "entry": ["**/*.{js,ts}"]
+    },
+    // The cypress plugin for knip is disabled because it cannot parse the JSX syntax that our config files transitively include.
+    // These entries allow knip to follow the cypress config files without parsing the JSX.
+    "x-pack/platform/plugins/shared/fleet/cypress": {
+      "entry": ["**/*.ts"]
+    },
+    "x-pack/solutions/observability/plugins/apm/ftr_e2e": {
+      "entry": ["**/*.ts"]
+    },
+    "x-pack/solutions/security/plugins/security_solution": {
+      "entry": ["public/management/cypress/**/*.{ts,tsx}"]
     }
   }
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,19 +1,25 @@
 // Configuration for `knip` (https://knip.dev).
 //
-// Kibana uses a single root `package.json` and links packages via `link:` rather than yarn workspaces,
-// so this file is the source of truth for what knip should analyze. Add more workspaces here as
-// additional areas of the monorepo are brought under knip-managed lint coverage.
+// Kibana is a pnpm workspace monorepo. Knip auto-discovers workspaces from `pnpm-workspace.yaml`.
 //
 // Usage:
 //   node scripts/knip [...args]
 //
-// Check for unused root dependencies (ignores @kbn/* and @elastic/*):
-//   node scripts/knip --workspace . --include dependencies,devDependencies
+// Find unused root dependencies/devDependencies:
+//   node scripts/knip --include dependencies,devDependencies
 //
-// Scope to a single workspace:
+// Scope to a single workspace (its ancestors, including root, are included automatically):
 //   node scripts/knip --workspace src/platform/packages/shared/kbn-safer-lodash-set --include unlisted
 {
   "$schema": "https://unpkg.com/knip@6/schema-jsonc.json",
+  // Disable the Playwright and Cypress plugins for every workspace (top-level plugin config
+  // is applied to all workspaces as a default). Knip's config loader tries to import each
+  // `playwright.config.ts` / `cypress.config.ts`, which transitively pulls in `*.text`
+  // mustache templates from @kbn/evals (Node can't load the `.text` extension without our
+  // runtime require hook) and hits a colorette bundling issue in the cypress configs. We
+  // don't need these config files for dependency analysis, so we skip loading them.
+  "playwright": false,
+  "cypress": false,
   // @kbn/* and @elastic/* are internal linked packages managed outside of knip.
   // @babel/plugin-* and babel-plugin-* are consumed via require.resolve() in
   // packages/kbn-babel-preset/ which knip cannot trace (it only detects require/import).
@@ -37,30 +43,15 @@
     "mocha-junit-reporter",
     "mocha-multi-reporters",
     "mochawesome",
-    "mochawesome-merge",
-    // nyc is invoked from shell scripts (.buildkite/scripts/steps/code_coverage/)
-    // and osquery's package.json scripts; knip can't trace shell usage.
-    "nyc",
+    // used by APM's Cypress e2e support files (ftr_e2e/); with the cypress plugin disabled
+    // (see above) knip no longer traces it through the cypress config/support chain.
+    "@frsource/cypress-plugin-visual-regression-diff",
     // oxlint is invoked as a binary via procRunner in @kbn/lint-cli;
     // knip can't trace dynamic cmd invocations.
     "oxlint"
   ],
   "workspaces": {
     ".": {
-      "entry": [
-        "src/**/*.{ts,tsx,js,jsx}",
-        "x-pack/**/*.{ts,tsx,js,jsx}",
-        "packages/**/*.{ts,tsx,js,jsx}",
-        "examples/**/*.{ts,tsx,js,jsx}",
-        "plugins/**/*.{ts,tsx,js,jsx}"
-      ],
-      "project": [
-        "src/**/*.{ts,tsx,js,jsx}",
-        "x-pack/**/*.{ts,tsx,js,jsx}",
-        "packages/**/*.{ts,tsx,js,jsx}",
-        "examples/**/*.{ts,tsx,js,jsx}",
-        "plugins/**/*.{ts,tsx,js,jsx}"
-      ],
       "ignore": [
         "**/node_modules/**",
         "**/target/**",
@@ -102,6 +93,17 @@
     },
     "src/platform/packages/shared/kbn-safer-lodash-set": {
       "entry": ["set.js", "setWith.js", "fp/*.js"]
+    },
+    "src/platform/packages/private/kbn-esql-scripts": {
+      // These are standalone CLI scripts invoked via ts-node from the package's shell scripts
+      // (definitions/make_defs.sh, documentation/make_docs.sh), not from an index/main entry.
+      // Declaring them as entries lets knip follow their imports.
+      "entry": ["definitions/generate_*.ts", "documentation/generate_*.ts"]
+    },
+    "src/platform/packages/shared/kbn-test": {
+      // Jest setup/polyfill/serializer files referenced from jest-preset.js via `<rootDir>/...`.
+      // knip can't resolve `<rootDir>` inside a shared preset.
+      "entry": ["src/jest/setup/*.{js,ts}"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2203,8 +2203,7 @@
     "xml-crypto": "6.1.2",
     "xmlbuilder": "15.1.1",
     "yaml-language-server": "1.23.0",
-    "yargs": "15.4.1",
-    "yarn-deduplicate": "6.0.2"
+    "yargs": "15.4.1"
   },
   "packageManager": "pnpm@9.15.9",
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -2023,7 +2023,6 @@
     "@typescript-eslint/parser": "8.46.3",
     "@typescript-eslint/typescript-estree": "8.46.3",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.7",
-    "@yarnpkg/lockfile": "1.1.0",
     "aggregate-error": "3.1.0",
     "ajv": "8.20.0",
     "ajv-draft-04": "1.0.0",

--- a/packages/kbn-capture-oas-snapshot-cli/package.json
+++ b/packages/kbn-capture-oas-snapshot-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./src/run_capture_oas_snapshot_cli"
+  "main": "./src/run_capture_oas_snapshot_cli.ts"
 }

--- a/packages/kbn-check-prod-native-modules-cli/package.json
+++ b/packages/kbn-check-prod-native-modules-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./run_check_prod_native_modules_cli"
+  "main": "./run_check_prod_native_modules_cli.ts"
 }

--- a/packages/kbn-ci-stats-shipper-cli/package.json
+++ b/packages/kbn-ci-stats-shipper-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./ship_ci_stats_cli"
+  "main": "./ship_ci_stats_cli.ts"
 }

--- a/packages/kbn-import-locator/package.json
+++ b/packages/kbn-import-locator/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./import_locator"
+  "main": "./import_locator.ts"
 }

--- a/packages/kbn-lint-cli/package.json
+++ b/packages/kbn-lint-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./run_lint_cli"
+  "main": "./run_lint_cli.ts"
 }

--- a/packages/kbn-lint-packages-cli/package.json
+++ b/packages/kbn-lint-packages-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./run_lint_packages_cli"
+  "main": "./run_lint_packages_cli.ts"
 }

--- a/packages/kbn-lint-ts-projects-cli/package.json
+++ b/packages/kbn-lint-ts-projects-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./run_lint_ts_projects_cli"
+  "main": "./run_lint_ts_projects_cli.ts"
 }

--- a/packages/kbn-picomatcher/package.json
+++ b/packages/kbn-picomatcher/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./make_matcher"
+  "main": "./make_matcher.ts"
 }

--- a/packages/kbn-plugin-helpers/package.json
+++ b/packages/kbn-plugin-helpers/package.json
@@ -4,7 +4,5 @@
   "private": true,
   "description": "Just some helpers for kibana plugin devs.",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "bin": {
-    "plugin-helpers": "bin/plugin-helpers.js"
-  }
+  "main": "./index.ts"
 }

--- a/packages/kbn-set-map/package.json
+++ b/packages/kbn-set-map/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./set_map"
+  "main": "./set_map.ts"
 }

--- a/packages/kbn-ts-type-check-cli/package.json
+++ b/packages/kbn-ts-type-check-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./index"
+  "main": "./index.ts"
 }

--- a/packages/kbn-validate-next-docs-cli/package.json
+++ b/packages/kbn-validate-next-docs-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./validate_next_docs_cli"
+  "main": "./validate_next_docs_cli.ts"
 }

--- a/packages/kbn-whereis-pkg-cli/package.json
+++ b/packages/kbn-whereis-pkg-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./run_whereis_pkg_cli"
+  "main": "./run_whereis_pkg_cli.ts"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5497,7 +5497,7 @@ importers:
         version: 2.35.1
       '@rsdoctor/rspack-plugin':
         specifier: 1.5.7
-        version: 1.5.7(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
+        version: 1.5.7(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rspack/core':
         specifier: 1.7.11
         version: 1.7.11(@swc/helpers@0.5.19)
@@ -6437,9 +6437,6 @@ importers:
       yargs:
         specifier: 15.4.1
         version: 15.4.1
-      yarn-deduplicate:
-        specifier: 6.0.2
-        version: 6.0.2
 
   examples/content_management_examples: {}
 
@@ -26508,11 +26505,6 @@ packages:
   yargs@3.32.0:
     resolution: {integrity: sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==}
 
-  yarn-deduplicate@6.0.2:
-    resolution: {integrity: sha512-Efx4XEj82BgbRJe5gvQbZmEO7pU5DgHgxohYZp98/+GwPqdU90RXtzvHirb7hGlde0sQqk5G3J3Woyjai8hVqA==}
-    engines: {node: '>=v14', yarn: '>=1 <2'}
-    hasBin: true
-
   yauzl@3.4.0:
     resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
@@ -32180,14 +32172,14 @@ snapshots:
 
   '@rsdoctor/client@1.5.7': {}
 
-  '@rsdoctor/core@1.5.7(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)':
+  '@rsdoctor/core@1.5.7(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1
       '@rsdoctor/graph': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/sdk': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/types': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/utils': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
-      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.49.0
       filesize: 10.1.6
@@ -32215,9 +32207,9 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.7(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)':
+  '@rsdoctor/rspack-plugin@1.5.7(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)':
     dependencies:
-      '@rsdoctor/core': 1.5.7(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
+      '@rsdoctor/core': 1.5.7(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/graph': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/sdk': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/types': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
@@ -32362,9 +32354,9 @@ snapshots:
   '@rspack/resolver-binding-linux-x64-musl@0.2.8':
     optional: true
 
-  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
+  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -32379,7 +32371,7 @@ snapshots:
   '@rspack/resolver-binding-win32-x64-msvc@0.2.8':
     optional: true
 
-  '@rspack/resolver@0.2.8(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
+  '@rspack/resolver@0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     optionalDependencies:
       '@rspack/resolver-binding-darwin-arm64': 0.2.8
       '@rspack/resolver-binding-darwin-x64': 0.2.8
@@ -32387,7 +32379,7 @@ snapshots:
       '@rspack/resolver-binding-linux-arm64-musl': 0.2.8
       '@rspack/resolver-binding-linux-x64-gnu': 0.2.8
       '@rspack/resolver-binding-linux-x64-musl': 0.2.8
-      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@rspack/resolver-binding-win32-arm64-msvc': 0.2.8
       '@rspack/resolver-binding-win32-ia32-msvc': 0.2.8
       '@rspack/resolver-binding-win32-x64-msvc': 0.2.8
@@ -47958,13 +47950,6 @@ snapshots:
       string-width: 1.0.2
       window-size: 0.1.4
       y18n: 3.2.2
-
-  yarn-deduplicate@6.0.2:
-    dependencies:
-      '@yarnpkg/lockfile': 1.1.0
-      commander: 10.0.1
-      semver: 7.8.0
-      tslib: 2.8.1
 
   yauzl@3.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5497,7 +5497,7 @@ importers:
         version: 2.35.1
       '@rsdoctor/rspack-plugin':
         specifier: 1.5.7
-        version: 1.5.7(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
+        version: 1.5.7(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rspack/core':
         specifier: 1.7.11
         version: 1.7.11(@swc/helpers@0.5.19)
@@ -5894,9 +5894,6 @@ importers:
       '@wojtekmaj/enzyme-adapter-react-17':
         specifier: 0.6.7
         version: 0.6.7(enzyme@3.11.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@yarnpkg/lockfile':
-        specifier: 1.1.0
-        version: 1.1.0
       aggregate-error:
         specifier: 3.1.0
         version: 3.1.0
@@ -7210,9 +7207,6 @@ importers:
 
   src/platform/packages/private/kbn-esql-scripts:
     devDependencies:
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@24.10.13)(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -8553,11 +8547,7 @@ importers:
 
   x-pack/platform/packages/shared/kbn-evals: {}
 
-  x-pack/platform/packages/shared/kbn-evals-common:
-    dependencies:
-      simple-statistics:
-        specifier: 7.8.8
-        version: 7.8.8
+  x-pack/platform/packages/shared/kbn-evals-common: {}
 
   x-pack/platform/packages/shared/kbn-evals-extensions: {}
 
@@ -8667,11 +8657,7 @@ importers:
 
   x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui: {}
 
-  x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form:
-    dependencies:
-      '@tanstack/react-query':
-        specifier: ^4.29.5
-        version: 4.29.12(react-dom@18.2.0(react@18.2.0))(react-native@0.86.0(@babel/core@7.26.8)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+  x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form: {}
 
   x-pack/platform/packages/shared/response-ops/alerting-v2-schemas: {}
 
@@ -15648,9 +15634,6 @@ packages:
 
   '@xyflow/system@0.0.77':
     resolution: {integrity: sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==}
-
-  '@yarnpkg/lockfile@1.1.0':
-    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
 
   '@zip.js/zip.js@2.8.26':
     resolution: {integrity: sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==}
@@ -28154,6 +28137,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@csstools/selector-specificity@2.2.0(postcss-selector-parser@6.1.4)':
     dependencies:
@@ -29880,6 +29864,7 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -32172,14 +32157,14 @@ snapshots:
 
   '@rsdoctor/client@1.5.7': {}
 
-  '@rsdoctor/core@1.5.7(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)':
+  '@rsdoctor/core@1.5.7(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1
       '@rsdoctor/graph': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/sdk': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/types': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/utils': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
-      '@rspack/resolver': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.49.0
       filesize: 10.1.6
@@ -32207,9 +32192,9 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.7(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)':
+  '@rsdoctor/rspack-plugin@1.5.7(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)':
     dependencies:
-      '@rsdoctor/core': 1.5.7(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
+      '@rsdoctor/core': 1.5.7(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/graph': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/sdk': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
       '@rsdoctor/types': 1.5.7(@rspack/core@1.7.11(@swc/helpers@0.5.19))(webpack@5.96.1)
@@ -32354,9 +32339,9 @@ snapshots:
   '@rspack/resolver-binding-linux-x64-musl@0.2.8':
     optional: true
 
-  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -32371,7 +32356,7 @@ snapshots:
   '@rspack/resolver-binding-win32-x64-msvc@0.2.8':
     optional: true
 
-  '@rspack/resolver@0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rspack/resolver@0.2.8(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     optionalDependencies:
       '@rspack/resolver-binding-darwin-arm64': 0.2.8
       '@rspack/resolver-binding-darwin-x64': 0.2.8
@@ -32379,7 +32364,7 @@ snapshots:
       '@rspack/resolver-binding-linux-arm64-musl': 0.2.8
       '@rspack/resolver-binding-linux-x64-gnu': 0.2.8
       '@rspack/resolver-binding-linux-x64-musl': 0.2.8
-      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
       '@rspack/resolver-binding-win32-arm64-msvc': 0.2.8
       '@rspack/resolver-binding-win32-ia32-msvc': 0.2.8
       '@rspack/resolver-binding-win32-x64-msvc': 0.2.8
@@ -33379,13 +33364,17 @@ snapshots:
       mkdirp: 1.0.4
       path-browserify: 1.0.1
 
-  '@tsconfig/node10@1.0.12': {}
+  '@tsconfig/node10@1.0.12':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@tsd/typescript@5.9.3': {}
 
@@ -34697,8 +34686,6 @@ snapshots:
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
 
-  '@yarnpkg/lockfile@1.1.0': {}
-
   '@zip.js/zip.js@2.8.26': {}
 
   abab@2.0.6: {}
@@ -34921,7 +34908,8 @@ snapshots:
 
   archy@1.0.0: {}
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   arg@5.0.2: {}
 
@@ -37199,7 +37187,8 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.4: {}
+  diff@4.0.4:
+    optional: true
 
   diff@5.2.2: {}
 
@@ -41257,7 +41246,8 @@ snapshots:
     dependencies:
       semver: 7.8.0
 
-  make-error@1.3.6: {}
+  make-error@1.3.6:
+    optional: true
 
   makeerror@1.0.12:
     dependencies:
@@ -46574,6 +46564,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.18(@swc/helpers@0.5.19)
+    optional: true
 
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
@@ -46995,7 +46986,8 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   v8-compile-cache@2.4.0: {}
 
@@ -47959,7 +47951,8 @@ snapshots:
     dependencies:
       buffer-crc32: 1.0.0
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -1367,7 +1367,7 @@
     },
     {
       "groupName": "package.json/yarn.lock utils",
-      "matchDepNames": ["@yarnpkg/lockfile", "sort-package-json", "yarn-deduplicate"],
+      "matchDepNames": ["sort-package-json"],
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "addLabels": ["Team:Operations"],

--- a/src/platform/packages/private/kbn-esql-scripts/package.json
+++ b/src/platform/packages/private/kbn-esql-scripts/package.json
@@ -13,7 +13,6 @@
     "lint:fix:docs": "cd ../../../../.. && node ./scripts/eslint --fix ./src/platform/packages/private/kbn-language-documentation/src/sections/generated"
   },
   "devDependencies": {
-    "ts-node": "^10.9.2",
     "typescript": "5.9.3"
   }
 }

--- a/src/platform/packages/private/kbn-get-repo-files/package.json
+++ b/src/platform/packages/private/kbn-get-repo-files/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
-  "main": "./get_repo_files"
+  "main": "./get_repo_files.ts"
 }

--- a/src/platform/packages/private/kbn-scout-reporting/package.json
+++ b/src/platform/packages/private/kbn-scout-reporting/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/scout-reporting",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0"
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
+  "main": "index.ts"
 }

--- a/src/platform/packages/shared/kbn-i18n/package.json
+++ b/src/platform/packages/shared/kbn-i18n/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@kbn/i18n",
-  "browser": "./src/browser",
+  "browser": "./src/browser.ts",
   "version": "1.0.0",
   "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0",
   "author": "Kibana Core",
-  "private": true
+  "private": true,
+  "main": "./index.ts"
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2847,7 +2847,7 @@
       "@typescript-eslint/parser": ["typings/@typescript-eslint/parser"],
       "@a2a-js/sdk/server": ["typings/@a2a-js-sdk/server"],
       "vega-lite": ["typings/vega/vega_lite"],
-      "vega-tooltip": ["typings/vega/vega_tooltip"],
+      "vega-tooltip": ["node_modules/vega-tooltip/build/index.d.ts"],
       "zod": ["node_modules/zod/v4/index.d.ts"],
       "zod/v4": ["node_modules/zod/v4/index.d.ts"],
       "zod/v4/core": ["node_modules/zod/v4/core/index.d.ts"],

--- a/x-pack/platform/packages/shared/kbn-evals-common/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-evals-common/moon.yml
@@ -9,8 +9,6 @@ owners:
   defaultOwner: '@elastic/nightshift-context-and-research-team'
 toolchains:
   default: node
-  javascript:
-    rootPackageDependenciesOnly: false
 language: typescript
 project:
   title: '@kbn/evals-common'

--- a/x-pack/platform/packages/shared/kbn-evals-common/package.json
+++ b/x-pack/platform/packages/shared/kbn-evals-common/package.json
@@ -7,8 +7,5 @@
   "scripts": {
     "openapi:generate": "node scripts/openapi/generate",
     "openapi:generate:debug": "node --inspect-brk scripts/openapi/generate"
-  },
-  "dependencies": {
-    "simple-statistics": "7.8.8"
   }
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/moon.yml
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/moon.yml
@@ -9,8 +9,6 @@ owners:
   defaultOwner: '@elastic/rna-project-team'
 toolchains:
   default: node
-  javascript:
-    rootPackageDependenciesOnly: false
 language: typescript
 project:
   title: '@kbn/alerting-v2-rule-form'

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/package.json
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/package.json
@@ -2,8 +2,5 @@
   "name": "@kbn/alerting-v2-rule-form",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0",
-  "dependencies": {
-    "@tanstack/react-query": "^4.29.5"
-  }
+  "license": "Elastic License 2.0"
 }

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/package.json
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0",
-  "main": "./run_type_check_cli"
+  "main": "./type_check.js"
 }


### PR DESCRIPTION
## Summary

Updates our `knip` configuration to support the migration to `pnpm`.

```sh
larry@Larrys-MacBook-Pro kibana % node scripts/knip.js --include dependencies,devDependencies
✂️  Excellent, Knip found no issues.
```